### PR TITLE
Rot 148 timezone encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* [ROT-148] at_time will maintain the configured timezone
+
 ## 0.2.0
 
 * Rails 5 support

--- a/lib/timely/rails/date.rb
+++ b/lib/timely/rails/date.rb
@@ -1,4 +1,13 @@
 class Date
+  def at_time(hour = nil, minute = nil, second = nil)
+    if hour.is_a?(Time)
+      time = hour
+      hour, minute, second = time.hour, time.min, time.sec
+    end
+
+    ::Time.zone.local(year, month, day, hour, minute, second)
+  end
+
   def to_time_in_time_zone
     (Time.zone || ActiveSupport::TimeZone["UTC"]).local(self.year, self.month, self.day)
   end

--- a/spec/rails/date_spec.rb
+++ b/spec/rails/date_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Date do
   let(:date) { Date.parse("2010-01-01") }
 
-  before { Time.zone = ActiveSupport::TimeZone["Adelaide"] }
+  before { Time.zone = 'Adelaide' }
 
   subject(:converted) { date.to_time_in_time_zone }
 
@@ -12,5 +12,9 @@ describe Date do
     expect(converted.month).to eq date.month
     expect(converted.day).to eq date.day
     expect(converted.time_zone).to eq Time.zone
+  end
+
+  it "should encode with the configured timezone" do
+    expect(date.at_time(12, 0, 0).zone).to eq Time.zone.now.zone
   end
 end


### PR DESCRIPTION
When using Rails we want to maintain the configured timezone when using at_time