### PR TITLE
Remove bootstrap class from calender_tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.3 Unreleased
+
+* [TT-4812] Remove bootstrap class from calender tag
+
 ## 0.3.2
 
 * [TT-4716] Better exception message when a range is invalid

--- a/lib/timely/rails/calendar_tag.rb
+++ b/lib/timely/rails/calendar_tag.rb
@@ -18,7 +18,7 @@ module Timely
 
         options[:class] = options[:class].split(' ') if options[:class].is_a?(String)
         options[:class] ||= []
-        options[:class] += %w(datepicker input-small)
+        options[:class] << 'datepicker'
         options[:class] = options[:class].join(' ') # Rails 2 requires string values
 
         options[:size] ||= 10

--- a/spec/calendar_tag_spec.rb
+++ b/spec/calendar_tag_spec.rb
@@ -17,7 +17,7 @@ describe Timely::ActionViewHelpers do
     expect(string).to receive(:html_safe)
     expect(subject).to receive(:tag).with(:input,
       :id    => 'test',
-      :class => 'datepicker input-small',
+      :class => 'datepicker',
       :size  => 10,
       :maxlength => 10,
       :name  => 'test',


### PR DESCRIPTION
We don't want to depend on this class as in Bootstrap 3 it forces the width with an `!important`