### PR TITLE
Tt 5674 fix multi year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* [TT-5674] Make multi year date format friendlier
+
 ## 0.4.0
 
 * [TT-5648] Fix date_range to string when a single month covers a year period

--- a/lib/timely/date_range.rb
+++ b/lib/timely/date_range.rb
@@ -58,8 +58,8 @@ module Timely
       if first && last
         if first == last
           first.strftime(fmt)
-        elsif first.year == last.year && first == first.at_beginning_of_month && last == last.at_end_of_month
-          if first.month == last.month
+        elsif first == first.at_beginning_of_month && last == last.at_end_of_month
+          if first.year == last.year && first.month == last.month
             first.strftime(month_fmt)
           else
             "#{first.strftime(month_fmt)} to #{last.strftime(month_fmt)}"

--- a/spec/date_range_spec.rb
+++ b/spec/date_range_spec.rb
@@ -27,7 +27,7 @@ describe Timely::DateRange do
     expect(Timely::DateRange.new('2000-01-04'.to_date, '2000-01-06'.to_date).to_s).to eq '2000-01-04 to 2000-01-06 (inclusive)'
     expect(Timely::DateRange.new('2000-01-01'.to_date, '2000-05-31'.to_date).to_s).to eq 'Jan 2000 to May 2000'
     expect(Timely::DateRange.new('2000-01-01'.to_date, '2000-01-31'.to_date).to_s).to eq 'Jan 2000'
-    expect(Timely::DateRange.new('2000-01-01'.to_date, '2001-01-31'.to_date).to_s).to eq '2000-01-01 to 2001-01-31 (inclusive)'
+    expect(Timely::DateRange.new('2000-01-01'.to_date, '2001-01-31'.to_date).to_s).to eq 'Jan 2000 to Jan 2001'
     Date::DATE_FORMATS[:short] = '%Y-%m-%d'
     expect(Timely::DateRange.to_s('2000-01-01'.to_date, nil)).to eq 'on or after 2000-01-01'
     expect(Timely::DateRange.to_s(nil, '2000-01-31'.to_date)).to eq 'on or before 2000-01-31'


### PR DESCRIPTION
**WHY**

Make the multi-year format more consistent with other generated strings

2000-01-01 to 2001-01-31 (inclusive) becomes Jan 2000 to Jan 2001