### PR TITLE
TT-5791: Fix belongs_to associations are not marked optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* [TT-5794] Fix belongs_to associations are not explicitly marked optional
+
 ## 0.4.1
 
 * [TT-5674] Make multi year date format friendlier

--- a/lib/timely/rails/date_group.rb
+++ b/lib/timely/rails/date_group.rb
@@ -1,6 +1,6 @@
 module Timely
   class DateGroup < ActiveRecord::Base
-    belongs_to :season, :class_name => 'Timely::Season'
+    belongs_to :season, :class_name => 'Timely::Season', optional: true
 
     weekdays_field :weekdays
 

--- a/lib/timely/rails/extensions.rb
+++ b/lib/timely/rails/extensions.rb
@@ -14,7 +14,7 @@ module Timely
     end
 
     def acts_as_seasonal
-      belongs_to :season, :class_name => 'Timely::Season'
+      belongs_to :season, :class_name => 'Timely::Season', optional: true
       accepts_nested_attributes_for :season
       validates_associated :season
 


### PR DESCRIPTION
WHY
Rails 5.2 defaults changed and belongs_to associations must now be present unless explicitly turned off.
HOW
Set optional: true flag on belongs_to associations.