### PR TITLE
TT-6402: Require date group weekdays bit field to be not null/nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [TT-6402] Require date group weekdays bit field to be not null/nil
+            IMPORTANT: Rails projects must add a migration to make this field not null!
 * [TT-6401] Remove Rails 3 support, unused methods
 
 ## 0.5.0

--- a/lib/timely/rails/date_group.rb
+++ b/lib/timely/rails/date_group.rb
@@ -6,9 +6,9 @@ module Timely
 
     weekdays_field :weekdays
 
+    validates :weekdays_bit_array, presence: true
     validates_presence_of :start_date, :end_date
     validate :validate_date_range!
-    validate :validate_weekdays_not_null
 
     scope :covering_date, lambda { |date|
       # Suitable for use with joins/merge!
@@ -107,10 +107,6 @@ module Timely
       return unless start_date && end_date && start_date > end_date
 
       raise ArgumentError, "Incorrect date range #{start_date} is before #{end_date}"
-    end
-
-    def validate_weekdays_not_null
-      errors.add(:weekdays, 'weekdays cannot be NULL') if weekdays_bit_array.nil?
     end
   end
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -11,7 +11,7 @@ ActiveRecord::Schema.define(version: 1) do
   end
 
   create_table :date_groups do |t|
-    t.integer :season_id, :weekdays_bit_array
+    t.integer :season_id, :weekdays_bit_array, null: false, default: Timely::WeekDays::ALL_WEEKDAYS.weekdays_int
     t.date :start_date, :end_date
   end
 end

--- a/spec/season_spec.rb
+++ b/spec/season_spec.rb
@@ -30,6 +30,25 @@ describe Timely::Season, 'in general' do
     expect(@simple_low_season.boundary_range).to eq('2009-01-01'.to_date..'2009-09-30'.to_date)
     expect(@simple_high_season.boundary_range).to eq('2009-04-01'.to_date..'2009-12-31'.to_date)
   end
+
+  context 'creating with nested attributes' do
+    subject { Timely::Season.new(date_groups_attributes: attrs) }
+
+    context 'with valid attributes' do
+      let(:attrs) { [ { 'start_date' => '2019-11-26' } ] }
+      it 'accepts nested date groups' do
+        expect(subject.date_groups).not_to be_empty
+        expect(subject.date_groups.first.start_date).to eq('2019-11-26'.to_date)
+      end
+    end
+
+    context 'invalid nested date groups' do
+      let(:attrs) { [ { 'start_date' => '' } ] }
+      it 'rejects nested date groups with nil start date' do
+        expect(subject.date_groups).to be_empty
+      end
+    end
+  end
 end
 
 # == Schema Information

--- a/spec/support/coverage_loader.rb
+++ b/spec/support/coverage_loader.rb
@@ -3,4 +3,4 @@
 require 'simplecov-rcov'
 require 'coveralls'
 require 'coverage/kit'
-Coverage::Kit.setup(minimum_coverage: 70.20)
+Coverage::Kit.setup(minimum_coverage: 70.15)

--- a/spec/support/coverage_loader.rb
+++ b/spec/support/coverage_loader.rb
@@ -3,4 +3,4 @@
 require 'simplecov-rcov'
 require 'coveralls'
 require 'coverage/kit'
-Coverage::Kit.setup(minimum_coverage: 70.25)
+Coverage::Kit.setup(minimum_coverage: 70.20)

--- a/spec/support/coverage_loader.rb
+++ b/spec/support/coverage_loader.rb
@@ -3,4 +3,4 @@
 require 'simplecov-rcov'
 require 'coveralls'
 require 'coverage/kit'
-Coverage::Kit.setup(minimum_coverage: 70.15)
+Coverage::Kit.setup(minimum_coverage: 70.25)


### PR DESCRIPTION
Weekdays field cannot be null, removing the case of faking null == ALL_WEEKDAYS.