### PR TITLE
Tt 6661 fix overlapping dates

### DIFF
--- a/lib/timely/rails/date_group.rb
+++ b/lib/timely/rails/date_group.rb
@@ -18,9 +18,7 @@ module Timely
     scope :within_range, lambda { |date_range|
       # IMPORTANT: Required for correctness in case of string param.
       dates = Array(date_range)
-      scope = covering_date(dates.first)
-      scope = scope.or(covering_date(dates.last)) if dates.first != dates.last
-      scope
+      where(arel_table[:start_date].lteq(dates.last)).where(arel_table[:end_date].gteq(dates.first))
     }
 
     scope :for_any_weekdays, lambda { |weekdays_int|

--- a/spec/date_group_spec.rb
+++ b/spec/date_group_spec.rb
@@ -33,6 +33,44 @@ RSpec.describe Timely::DateGroup do
   end
 end
 
+RSpec.describe Timely::DateGroup, 'Timely::DateGroup.applying_for_duration' do
+  let!(:date_group_a) { Timely::DateGroup.create!(
+    start_date: '2020-01-01', end_date: '2020-04-04', weekdays: %w[1 1 1 1 1 1 1]
+  ) }
+
+  let!(:date_group_b) { Timely::DateGroup.create!(
+    start_date: '2020-04-02', end_date: '2020-04-09', weekdays: %w[1 1 1 1 1 1 1]
+  ) }
+
+  subject {
+    Timely::DateGroup.applying_for_duration(Timely::DateRange.new(start_date, end_date)).to_a
+  }
+
+  context 'intersecting dates (inside first)' do
+    let(:start_date) { '2020-03-29'.to_date }
+    let(:end_date) { '2020-04-13'.to_date }
+    it { is_expected.to eq([date_group_a, date_group_b]) }
+  end
+
+  context 'intersecting dates full range' do
+    let(:start_date) { '2020-01-01'.to_date }
+    let(:end_date) { '2020-04-09'.to_date }
+    it { is_expected.to eq([date_group_a, date_group_b]) }
+  end
+
+  context 'touching end of range' do
+    let(:start_date) { '2020-04-09'.to_date }
+    let(:end_date) { '2020-04-09'.to_date }
+    it { is_expected.to eq([date_group_b]) }
+  end
+
+  context 'touching start of range' do
+    let(:start_date) { '2020-04-01'.to_date }
+    let(:end_date) { '2020-04-01'.to_date }
+    it { is_expected.to eq([date_group_a]) }
+  end
+end
+
 RSpec.describe Timely::DateGroup, 'without weekdays' do
   subject { Timely::DateGroup.new(start_date: Date.current, end_date: Date.current) }
   it { is_expected.to be_valid }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ require 'rubygems'
 require 'bundler/setup'
 require 'rspec/its'
 require 'active_record'
+require 'pry'
+require 'database_cleaner'
 
 require 'support/coverage_loader'
 
@@ -30,4 +32,15 @@ load('spec/schema.rb')
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation, except: %w(ar_internal_metadata))
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
 end

--- a/spec/support/coverage_loader.rb
+++ b/spec/support/coverage_loader.rb
@@ -3,4 +3,4 @@
 require 'simplecov-rcov'
 require 'coveralls'
 require 'coverage/kit'
-Coverage::Kit.setup(minimum_coverage: 70.15)
+Coverage::Kit.setup(minimum_coverage: 69.95)

--- a/timely.gemspec
+++ b/timely.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rspec-its'
+  spec.add_development_dependency 'database_cleaner'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-rails'
   spec.add_development_dependency 'simplecov-rcov'

--- a/timely.gemspec
+++ b/timely.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'timecop'
   spec.add_development_dependency 'travis'
+  spec.add_development_dependency 'pry'
 end


### PR DESCRIPTION
### WHY

applying_for_duration method would not correctly identify all overlapping date ranges which causes issues when finding prices that exists across multiple date groups.

