### PR TITLE
Ensure the object gets converted with to_fs if it is a date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* [PLAT-954] Handle additional `to_s` deprecation on Rails 7
+
 ## 0.11.0
 
 * [PLAT-346] Handle `to_s` deprecation on Rails 7

--- a/lib/timely/rails/calendar_tag.rb
+++ b/lib/timely/rails/calendar_tag.rb
@@ -27,6 +27,10 @@ module Timely
         options[:size] ||= 10
         options[:maxlength] ||= 10
 
+        if options[:object].respond_to?(:to_fs)
+          options[:object] = options[:object].to_fs(:default)
+        end
+
         tag(:input, options.merge(name: name, type: 'text', value: value)).html_safe
       end
     end
@@ -41,6 +45,7 @@ module Timely
     module FormBuilder
       def calendar(method, options = {})
         options[:object] = @object.send(method) unless options.key?(:object)
+
         @template.calendar(@object_name, method, options)
       end
     end


### PR DESCRIPTION
### WHY

Fix a ```to_fs``` deprecation warning when using the calendar_tag